### PR TITLE
Return null if cannot get or store deviceid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,24 +1,25 @@
-# Compiled class file
-*.class
+# Maven build
+target/
 
-# Log file
-*.log
+# IntelliJ
+.idea/
+*.iml
+*.ipr
+*.iws
 
-# BlueJ files
-*.ctxt
+# VS Code
+.vscode/
+.history
 
-# Mobile Tools for Java (J2ME)
-.mtj.tmp/
+# Maven
+.mvn
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+release.properties
+dependency-reduced-pom.xml
+buildNumber.properties
 
-# Package Files #
-*.jar
-*.war
-*.nar
-*.ear
-*.zip
-*.tar.gz
-*.rar
-
-# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
-hs_err_pid*
-replay_pid*
+# MacOS
+.DS_Store

--- a/linux/src/main/java/com/microsoft/deviceid/LinuxDeviceId.java
+++ b/linux/src/main/java/com/microsoft/deviceid/LinuxDeviceId.java
@@ -9,19 +9,29 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 /**
  * Linux implementation of DeviceId.
+ * <ol>
+ * <li>The folder path will be &lt;RootPath&gt;/Microsoft/DeveloperTools where &lt;RootPath&gt; 
+ * is $XDG_CACHE_HOME if it is set and not empty, else use $HOME/.cache.</li>
+ * <li>The file will be called 'deviceid'.</li>
+ * <li>The value should be stored in plain text, UTF-8.</li> 
+ * </ol>
  */
 class LinuxDeviceId extends DeviceId {
     
     private static final String FOLDER = "Microsoft/DeveloperTools";
 
     @Override
-    protected String getDeviceId() throws IOException {
-        String cacheHome = System.getenv("XDG_CACHE_HOME");
-        if (cacheHome == null || cacheHome.isEmpty()) {
-            cacheHome = System.getProperty("user.home");
+    protected String getDeviceId() {
+        try {
+            String cacheHome = System.getenv("XDG_CACHE_HOME");
+            if (cacheHome == null || cacheHome.isEmpty()) {
+                cacheHome = System.getProperty("user.home");
+            }
+            Path rootPath = Paths.get(cacheHome, ".cache");
+            return getDeviceId(rootPath);
+        } catch (IOException e) {
+            return null;
         }
-        Path rootPath = Paths.get(cacheHome, ".cache");
-        return getDeviceId(rootPath);
     }
     
     // decouple getting the rootPath from this logic to allow for testing

--- a/macosx/src/main/java/com/microsoft/deviceid/MacDeviceId.java
+++ b/macosx/src/main/java/com/microsoft/deviceid/MacDeviceId.java
@@ -9,15 +9,24 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 /**
  * Dev Device ID for Mac OS X.
+ * <ol>
+ * <li>The folder path will be &lt;RootPath&gt;/Library/Application Support/Microsoft/DeveloperTools where &lt;RootPath&gt; is $HOME.</li>
+ * <li>The file will be called 'deviceid'.</li>
+ * <li>The value should be stored in plain text, UTF-8.</li>
+ * </ol>
  */
 class MacDeviceId extends DeviceId {
     
     private static final String FOLDER = "Library/Application Support/Microsoft/DeveloperTools";
 
     @Override
-    protected String getDeviceId() throws IOException {
-        Path rootPath = Paths.get(System.getProperty("user.home"));
-        return getDeviceId(rootPath);
+    protected String getDeviceId() {
+        try {
+            Path rootPath = Paths.get(System.getProperty("user.home"));
+            return getDeviceId(rootPath);
+        } catch (IOException e) {
+            return null;
+        }
     }
 
     // decouple getting the rootPath from this logic to allow for testing

--- a/src/main/java/com/microsoft/deviceid/DefaultDeviceId.java
+++ b/src/main/java/com/microsoft/deviceid/DefaultDeviceId.java
@@ -20,26 +20,8 @@ public class DefaultDeviceId extends DeviceId {
     }
 
     @Override
-    protected String getDeviceId() throws IOException {
-        Path rooPath = Paths.get(System.getProperty("user.home"), ".cache");
-        return getDeviceId(rooPath);
+    protected String getDeviceId() {
+        return null;
     }
 
-    // decouple getting the rootPath from this logic to allow for testing
-    String getDeviceId(Path rootPath) throws IOException {
-        Path path = rootPath.resolve(FOLDER);
-        if (!Files.exists(path)) {
-            Files.createDirectories(path);
-        }
-        Path deviceid = path.resolve("deviceid");
-        if (!Files.exists(deviceid)) {
-            Files.createFile(deviceid);
-        }
-        String uuid = new String(Files.readAllBytes(deviceid), java.nio.charset.StandardCharsets.UTF_8);
-        if (uuid == null || uuid.isEmpty()) {
-            uuid = java.util.UUID.randomUUID().toString();
-            Files.write(deviceid, uuid.getBytes(java.nio.charset.StandardCharsets.UTF_8));
-        }
-        return uuid;
-    }
 }

--- a/src/main/java/com/microsoft/deviceid/DeviceId.java
+++ b/src/main/java/com/microsoft/deviceid/DeviceId.java
@@ -41,21 +41,26 @@ public abstract class DeviceId {
     }
 
     /**
-     * Gets the device ID.
-     * @return the device ID
-     * @throws IOException if an I/O error occurs
+     * Gets the device ID. The value is a UUID. In the case where the cached
+     * id cannot be retrieved, or the newly generated id cannot be cached,
+     * a value of {@code null} should be returned.
+     * @return the device ID, or {@code null} if the ID cannot be retrieved
      */
-    public static String deviceId() throws IOException {
+    public static String deviceId() {
         return INSTANCE.getDeviceId();
     }
 
     /**
-     * Operating system specific method to get the device ID. The implementation
-     * will create the ID if it does not exist.
-     * @return the device ID
-     * @throws IOException if an I/O error occurs
+     * Operating system specific method to get the device ID. The value is a UUID
+     * that follows the 8-4-4-4-12 format. The value shall be all lowercase and
+     * only contain hyphens. No braces or brackets.
+     * <p>
+     * The implementation will create the ID if it does not exist. In the case
+     * where the cached id cannot be retrieved, or the newly generated id cannot
+     * be cached, a value of {@code null} should be returned.
+     * @return the device ID, or {@code null} if the ID cannot be retrieved
      */
-    protected abstract String getDeviceId() throws IOException;
+    protected abstract String getDeviceId();
 
     protected DeviceId() {}
 

--- a/src/test/java/com/microsoft/deviceid/DefaultDeviceIdTest.java
+++ b/src/test/java/com/microsoft/deviceid/DefaultDeviceIdTest.java
@@ -6,54 +6,20 @@ package com.microsoft.deviceid;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class DefaultDeviceIdTest {
 
     private DefaultDeviceId defaultDeviceId;
-    private Path testPath;
 
     @BeforeEach
     public void setUp() throws IOException {
         defaultDeviceId = new DefaultDeviceId();
-        testPath = Files.createTempDirectory("deviceid-test");
     }
 
     @Test
-    public void testGetDeviceIdCreatesDirectoryAndFile() throws IOException {
-        String deviceId = defaultDeviceId.getDeviceId(testPath);
-        assertTrue(Files.exists(testPath));
-        assertTrue(Files.exists(testPath.resolve("Microsoft/DeveloperTools/deviceid")));
-        assertNotNull(deviceId);
-        assertFalse(deviceId.isEmpty());
-    }
-
-    @Test
-    public void testGetDeviceIdReturnsSameId() throws IOException {
-        String deviceId1 = defaultDeviceId.getDeviceId(testPath);
-        String deviceId2 = defaultDeviceId.getDeviceId(testPath);
-        assertEquals(deviceId1, deviceId2);
-    }
-
-    @Test
-    public void testGetDeviceIdGeneratesNewIdIfFileIsEmpty() throws IOException {
-        Path deviceIdFile = testPath.resolve("Microsoft/DeveloperTools/deviceid");
-        Files.createDirectories(deviceIdFile.getParent());
-        Files.createFile(deviceIdFile);
-        String deviceId = defaultDeviceId.getDeviceId(testPath);
-        assertNotNull(deviceId);
-        assertFalse(deviceId.isEmpty());
-    }
-
-    @Test
-    public void testGetDeviceIdReadsExistingId() throws IOException {
-        Path deviceIdFile = testPath.resolve("Microsoft/DeveloperTools/deviceid");
-        Files.createDirectories(deviceIdFile.getParent());
-        String expectedId = "test-uuid";
-        Files.write(deviceIdFile, expectedId.getBytes(java.nio.charset.StandardCharsets.UTF_8));
-        String deviceId = defaultDeviceId.getDeviceId(testPath);
-        assertEquals(expectedId, deviceId);
+    public void testGetDeviceIdReturnsNull() {
+        String deviceId = defaultDeviceId.getDeviceId();
+        assertNull(deviceId);
     }
 }

--- a/windows/src/main/java/com/microsoft/deviceid/WindowsDeviceId.java
+++ b/windows/src/main/java/com/microsoft/deviceid/WindowsDeviceId.java
@@ -13,35 +13,42 @@ import static com.sun.jna.platform.win32.WinNT.KEY_WRITE;
 
 /**
  * Windows implementation of DeviceId.
+ * <ol>
+ * <li>The value is cached in the 64-bit Windows Registry under HKeyCurrentUser\SOFTWARE\Microsoft\DeveloperTools.</li>
+ * <li>The key should be named 'deviceid' and should be of type REG_SZ (String value).</li>
+ * <li>The value should be stored in plain text.</li>
+ * </ol>
  */
 class WindowsDeviceId extends DeviceId {
     
     private static final String REGISTRY_KEY = "Software\\Microsoft\\DeveloperTools";
 
     @Override
-    protected String getDeviceId() throws IOException {
-        return getDeviceId(REGISTRY_KEY);
+    protected String getDeviceId() {
+        // In case the cached id cannot be retrieved, or the newly generated
+        // id cannot be cached, a value of null should be returned
+        try {
+            return getDeviceId(REGISTRY_KEY);
+        } catch (Win32Exception e) {
+            return null;
+        }
     }
 
     // decouple getting the registry key from this logic to allow for testing
-    String getDeviceId(String registryKey) throws IOException {
-        try {
-            if (!Advapi32Util.registryKeyExists(HKEY_CURRENT_USER, REGISTRY_KEY)) {
-                Advapi32Util.registryCreateKey(HKEY_CURRENT_USER, REGISTRY_KEY, KEY_WRITE);
-            }
-
-            if (!Advapi32Util.registryValueExists(HKEY_CURRENT_USER, REGISTRY_KEY, "deviceid")) {
-                Advapi32Util.registryCreateKey(HKEY_CURRENT_USER, REGISTRY_KEY, "deviceid", KEY_WRITE);
-            }
-            String uuid = Advapi32Util.registryGetStringValue(HKEY_CURRENT_USER, REGISTRY_KEY, "deviceid");
-            if (uuid == null || uuid.isEmpty()) {
-                uuid = java.util.UUID.randomUUID().toString();
-                Advapi32Util.registrySetStringValue(HKEY_CURRENT_USER, REGISTRY_KEY, "deviceid", uuid);
-            } 
-            return uuid;
-        } catch (Win32Exception e) {
-            throw new IOException(e);
+    String getDeviceId(String registryKey) throws Win32Exception {
+        if (!Advapi32Util.registryKeyExists(HKEY_CURRENT_USER, REGISTRY_KEY)) {
+            Advapi32Util.registryCreateKey(HKEY_CURRENT_USER, REGISTRY_KEY, KEY_WRITE);
         }
+
+        if (!Advapi32Util.registryValueExists(HKEY_CURRENT_USER, REGISTRY_KEY, "deviceid")) {
+            Advapi32Util.registryCreateKey(HKEY_CURRENT_USER, REGISTRY_KEY, "deviceid", KEY_WRITE);
+        }
+        String uuid = Advapi32Util.registryGetStringValue(HKEY_CURRENT_USER, REGISTRY_KEY, "deviceid");
+        if (uuid == null || uuid.isEmpty()) {
+            uuid = java.util.UUID.randomUUID().toString();
+            Advapi32Util.registrySetStringValue(HKEY_CURRENT_USER, REGISTRY_KEY, "deviceid", uuid);
+        } 
+        return uuid;
     }
 
 }


### PR DESCRIPTION
Spec calls for returning null if the id can not be read or saved. Changed getDeviceId to no longer throw IOException but, instead, return null.  
I also added relevant information from spec to javadoc